### PR TITLE
Feature/improve workspace

### DIFF
--- a/src/cljc/witan/gateway/schema.cljc
+++ b/src/cljc/witan/gateway/schema.cljc
@@ -22,7 +22,7 @@
 
 (defn semver?
   [x]
-  (re-find #"^\d+\.\d+\.\d+$" "1.0.0"))
+  (re-find #"^\d+\.\d+\.\d+$" x))
 
 (def Semver
   (s/pred semver?))

--- a/src/cljc/witan/gateway/schema.cljc
+++ b/src/cljc/witan/gateway/schema.cljc
@@ -22,7 +22,7 @@
 
 (defn semver?
   [x]
-  (re-find #"(?<=^[Vv]|^)\d+\.\d+\.\d+$" x))
+  (re-find #"^\d+\.\d+\.\d+$" "1.0.0"))
 
 (def Semver
   (s/pred semver?))
@@ -111,6 +111,7 @@
 
 (defn validate-message
   ([version msg]
+   (s/validate Semver version)
    (-> Message
        (get version)
        (s/validate msg)))
@@ -120,6 +121,7 @@
 
 (defn check-message
   [version msg]
+  (s/validate Semver version)
   (-> Message
       (get version)
       (s/check msg)))
@@ -140,12 +142,14 @@
 
 (defn validate-workspace
   [version msg]
+  (s/validate Semver version)
   (-> WorkspaceMessage
       (get version)
       (s/validate msg)))
 
 (defn check-workspace
   [version msg]
+  (s/validate Semver version)
   (-> WorkspaceMessage
       (get version)
       (s/check msg)))

--- a/src/cljc/witan/gateway/schema.cljc
+++ b/src/cljc/witan/gateway/schema.cljc
@@ -20,12 +20,19 @@
   [m]
   (contains? m :command/error))
 
+(defn semver?
+  [x]
+  (re-find #"(?<=^[Vv]|^)\d+\.\d+\.\d+$" x))
+
+(def Semver
+  (s/pred semver?))
+
 (def DateTime
   #? (:clj  sc/ISO-Date-Time
       :cljs s/Str))
 
 (defversions MessageBase
-  "1.0"
+  "1.0.0"
   {:message/type (s/enum :query
                          :query-response
                          :command
@@ -34,57 +41,57 @@
                          :event)})
 
 (defversions Query
-  "1.0"
-  (merge (get MessageBase "1.0")
+  "1.0.0"
+  (merge (get MessageBase "1.0.0")
          {:query/id s/Any
           :query/edn s/Any}))
 
 (defversions QueryResponseBase
-  "1.0"
-  (merge (get MessageBase "1.0")
+  "1.0.0"
+  (merge (get MessageBase "1.0.0")
          {:query/id s/Any}))
 
 (defversions QueryResponse
-  "1.0"
-  (s/conditional query-error? (merge (get QueryResponseBase "1.0")
+  "1.0.0"
+  (s/conditional query-error? (merge (get QueryResponseBase "1.0.0")
                                      {:query/error s/Str})
-                 :else        (merge (get QueryResponseBase "1.0")
+                 :else        (merge (get QueryResponseBase "1.0.0")
                                      {:query/results [s/Any]})))
 
 (defversions Command
-  "1.0"
-  (merge (get MessageBase "1.0")
+  "1.0.0"
+  (merge (get MessageBase "1.0.0")
          {:command/key s/Keyword
-          :command/version s/Str
+          :command/version Semver
           :command/id s/Any
           (s/optional-key :command/receipt) s/Uuid
           (s/optional-key :command/created-at) DateTime
           (s/optional-key :command/params) s/Any}))
 
 (defversions CommandProcessed
-  "1.0"
-  (merge (get MessageBase "1.0")
+  "1.0.0"
+  (merge (get MessageBase "1.0.0")
          {:command/key s/Keyword
-          :command/version s/Str
+          :command/version Semver
           :command/id s/Any
           :command/receipt s/Uuid
           :command/created-at DateTime
           (s/optional-key :command/params) s/Any}))
 
 (defversions CommandReceipt
-  "1.0"
-  (merge (get MessageBase "1.0")
+  "1.0.0"
+  (merge (get MessageBase "1.0.0")
          {:command/key s/Keyword
-          :command/version s/Str
+          :command/version Semver
           :command/id s/Any
           :command/receipt s/Uuid
           :command/received-at DateTime}))
 
 (defversions Event
-  "1.0"
-  (merge (get MessageBase "1.0")
+  "1.0.0"
+  (merge (get MessageBase "1.0.0")
          {:event/key s/Keyword
-          :event/version s/Str
+          :event/version Semver
           :event/params s/Any
           ;;
           :event/id s/Uuid
@@ -93,14 +100,14 @@
           :command/receipt s/Uuid}))
 
 (defversions Message
-  "1.0"
+  "1.0.0"
   (s/conditional
-   (partial compare-message-type :query)             (get Query "1.0")
-   (partial compare-message-type :query-response)    (get QueryResponse "1.0")
-   (partial compare-message-type :command)           (get Command "1.0")
-   (partial compare-message-type :command-processed) (get CommandProcessed "1.0")
-   (partial compare-message-type :command-receipt)   (get CommandReceipt "1.0")
-   (partial compare-message-type :event)             (get Event "1.0")))
+   (partial compare-message-type :query)             (get Query "1.0.0")
+   (partial compare-message-type :query-response)    (get QueryResponse "1.0.0")
+   (partial compare-message-type :command)           (get Command "1.0.0")
+   (partial compare-message-type :command-processed) (get CommandProcessed "1.0.0")
+   (partial compare-message-type :command-receipt)   (get CommandReceipt "1.0.0")
+   (partial compare-message-type :event)             (get Event "1.0.0")))
 
 (defn validate-message
   ([version msg]
@@ -121,12 +128,14 @@
 ;; Workspace
 
 (defversions WorkspaceMessage
-  "1.0"
+  "1.0.0"
   {:workspace/name s/Str
    :workspace/id s/Uuid
    :workspace/owner-id s/Uuid
    :workspace/description s/Str
    :workspace/modified DateTime
+   (s/optional-key :workspace/workflow)  [s/Any]
+   (s/optional-key :workspace/catalog)   [s/Any]
    (s/optional-key :workspace/owner-name) s/Str})
 
 (defn validate-workspace

--- a/src/cljc/witan/gateway/schema.cljc
+++ b/src/cljc/witan/gateway/schema.cljc
@@ -20,65 +20,96 @@
   [m]
   (contains? m :command/error))
 
-(def MessageBase
+(def DateTime
+  #? (:clj  sc/ISO-Date-Time
+      :cljs s/Str))
+
+(defversions MessageBase
+  "1.0"
   {:message/type (s/enum :query
                          :query-response
                          :command
                          :command-receipt
+                         :command-processed
                          :event)})
 
-(def Query
-  (merge MessageBase
+(defversions Query
+  "1.0"
+  (merge (get MessageBase "1.0")
          {:query/id s/Any
           :query/edn s/Any}))
 
-(def QueryResponseBase
-  (merge MessageBase
+(defversions QueryResponseBase
+  "1.0"
+  (merge (get MessageBase "1.0")
          {:query/id s/Any}))
 
-(def QueryResponse
-  (s/conditional query-error? (merge QueryResponseBase
+(defversions QueryResponse
+  "1.0"
+  (s/conditional query-error? (merge (get QueryResponseBase "1.0")
                                      {:query/error s/Str})
-                 :else        (merge QueryResponseBase
+                 :else        (merge (get QueryResponseBase "1.0")
                                      {:query/results [s/Any]})))
 
-(def Command
-  (merge MessageBase
+(defversions Command
+  "1.0"
+  (merge (get MessageBase "1.0")
          {:command/key s/Keyword
           :command/version s/Str
           :command/id s/Any
+          (s/optional-key :command/receipt) s/Uuid
+          (s/optional-key :command/created-at) DateTime
           (s/optional-key :command/params) s/Any}))
 
-(def CommandReceipt
-  (merge MessageBase
+(defversions CommandProcessed
+  "1.0"
+  (merge (get MessageBase "1.0")
          {:command/key s/Keyword
           :command/version s/Str
           :command/id s/Any
-          :command/receipt s/Uuid}))
+          :command/receipt s/Uuid
+          :command/created-at DateTime
+          (s/optional-key :command/params) s/Any}))
 
-(def Event
-  (merge MessageBase
+(defversions CommandReceipt
+  "1.0"
+  (merge (get MessageBase "1.0")
+         {:command/key s/Keyword
+          :command/version s/Str
+          :command/id s/Any
+          :command/receipt s/Uuid
+          :command/received-at DateTime}))
+
+(defversions Event
+  "1.0"
+  (merge (get MessageBase "1.0")
          {:event/key s/Keyword
           :event/version s/Str
           :event/params s/Any
-          :event/created-at #? (:clj  sc/ISO-Date-Time
-                                :cljs s/Str)
+          ;;
+          :event/id s/Uuid
+          :event/created-at DateTime
+          :event/origin s/Str
           :command/receipt s/Uuid}))
 
 (defversions Message
   "1.0"
   (s/conditional
-   (partial compare-message-type :query)           Query
-   (partial compare-message-type :query-response)  QueryResponse
-   (partial compare-message-type :command)         Command
-   (partial compare-message-type :command-receipt) CommandReceipt
-   (partial compare-message-type :event)           Event))
+   (partial compare-message-type :query)             (get Query "1.0")
+   (partial compare-message-type :query-response)    (get QueryResponse "1.0")
+   (partial compare-message-type :command)           (get Command "1.0")
+   (partial compare-message-type :command-processed) (get CommandProcessed "1.0")
+   (partial compare-message-type :command-receipt)   (get CommandReceipt "1.0")
+   (partial compare-message-type :event)             (get Event "1.0")))
 
 (defn validate-message
-  [version msg]
-  (-> Message
-      (get version)
-      (s/validate msg)))
+  ([version msg]
+   (-> Message
+       (get version)
+       (s/validate msg)))
+  ([version type msg]
+   (s/validate (s/eq type) (:message/type msg))
+   (validate-message version msg)))
 
 (defn check-message
   [version msg]
@@ -89,20 +120,23 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Workspace
 
-(defversions Workspace
+(defversions WorkspaceMessage
   "1.0"
   {:workspace/name s/Str
-   :workspace/id s/Str
-   :workspace/owner s/Str})
+   :workspace/id s/Uuid
+   :workspace/owner-id s/Uuid
+   :workspace/description s/Str
+   :workspace/modified DateTime
+   (s/optional-key :workspace/owner-name) s/Str})
 
 (defn validate-workspace
   [version msg]
-  (-> Workspace
+  (-> WorkspaceMessage
       (get version)
       (s/validate msg)))
 
 (defn check-workspace
   [version msg]
-  (-> Workspace
+  (-> WorkspaceMessage
       (get version)
       (s/check msg)))

--- a/test/witan/gateway/schema_test.clj
+++ b/test/witan/gateway/schema_test.clj
@@ -2,6 +2,19 @@
   (:require [clojure.test :refer :all]
             [witan.gateway.schema :refer :all]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(deftest semvar-test
+  (is (semver? "1.0.0"))
+  (is (semver? "1.2.3"))
+  (is (not (semver? "1.2.")))
+  (is (not (semver? "1.2")))
+  (is (not (semver? "1.2")))
+  (is (not (semver? "1.")))
+  (is (not (semver? "1")))
+  (is (not (semver? "")))
+  (is (not (semver? "foobar1.2.3")))
+  (is (not (semver? "foobar1.2.3foobar")))
+  (is (not (semver? "1.2.3foobar")))
+  (is (not (semver? "v1.2.3")))
+  (is (not (semver? "V1.2.3")))
+  (is (not (semver? "1.2.3v")))
+  (is (not (semver? "1.2.3V"))))


### PR DESCRIPTION
Following a commitment to 'SemVer everywhere', drop the `s/Str` schema for versions and use the `Semver` predicate instead - internally uses regex to check for a simple "X.Y.Z" string.

Also using `defversion` for a lot of the core schema in case we adjust them later.
